### PR TITLE
Update for SMAPI 3.0, add readme + release notes, fix issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,39 @@
-# Sauvignon-in-Stardew
-A Stardew Valley Mod
+**Sauvignon in Stardew** is a [Stardew Valley](http://stardewvalley.net/) mod which lets you build
+a beautiful winery via Robin. Takes 4 days to construct. Once built, all kegs and casks work 30%
+faster inside the building and show time remaining on mouse over.
 
-Add the option to build a beautiful winery from Robin. Takes 4 days to construct. Once built, all kegs and casks work 30% faster inside the building and show time remaining on mouse over.
+## Install
+1. [Install the latest version of SMAPI](https://smapi.io/).
+2. Install [this mod from Nexus mods](http://www.nexusmods.com/stardewvalley/mods/2597).
+3. Run the game using SMAPI.
+
+## Use
+You can build the Winery building through Robin's carpentry menu. It costs 40 000 Gold, 200
+Hardwood, 100 Clay, and 100 Stone, and takes four days to construct. The building is 11 tiles wide
+by 6 tiles deep. The building textures are automatically seasonal, and features a walk-through
+archway.
+
+Inside the winery, a lovely music track plays. Casks can be used inside the building. Casks and
+kegs inside the building work 30% faster, and show a tooltip with the product and time remaining
+when you point at them.
+
+At level 10 farming, you can choose a new Distiller profession in the tiller branch. This adds a
+40% sell bonus to all alcohol (including wines, beers, meads, and IPAs), which are part of a new
+Distilled Craft category. The Artisan profession no longer affects alcohols.
+
+## Configure
+The mod creates a `config.json` file in its mod folder the first time you run it. You can open that
+file in a text editor to configure the mod.
+
+These are the available settings:
+
+| setting                   | what it affects
+| ------------------------- | -------------------
+| `DistillerProfessionBool` | Default `true`. Whether to add the new Distiller profession. (Disabling this will return the Artisan profession to normal.)
+
+## Compatibility
+Sauvignon is compatible with Stardew Valley 1.3+ on Linux/Mac/Windows. Not tested in multiplayer.
+
+## See also
+* [release notes](RELEASE-NOTES.md)
+* [Nexus mod](http://www.nexusmods.com/stardewvalley/mods/2597)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,7 +6,7 @@
 * Updated for Stardew Valley 1.3.32, SMAPI 2.9, and the upcoming SMAPI 3.0.
 * Fixed errors due to broken syntax in the i18n files.
 * Fixed errors when a winery is outside the map bounds (e.g. because a custom map was removed).
-* Fixed the new assets not getting copied into the Mods folder or release zip.
+* Fixed lag inside the winery for some players.
 
 ## 1.9
 * HOPEFULLY fixed Distiller craft bug.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,57 @@
+[← back to readme](README.md)
+
+# Release notes
+## Upcoming release
+* Winery data is now stored in the save file. (Existing wineries will be migrated next time you save.
+* Updated for Stardew Valley 1.3.32, SMAPI 2.9, and the upcoming SMAPI 3.0.
+* Fixed errors due to broken syntax in the i18n files.
+* Fixed errors when a winery is outside the map bounds (e.g. because a custom map was removed).
+* Fixed the new assets not getting copied into the Mods folder or release zip.
+
+## 1.9
+* HOPEFULLY fixed Distiller craft bug.
+
+## 1.8
+* Added compatibility with SpaceCore.
+* Fixed compatibility with All Professions.
+
+## 1.7
+* Added compatibility with mods like All Professions.
+* Added mouse pointer to SkillsPage hovering.
+* Fixed compatibility issue with CJB Item Spawner.
+
+## 1.6
+* Fixed the Distiller profession.
+* Removed test code that affected kegs.
+
+## 1.5
+* Added music for the Winery. :D
+* Added option to disable Distiller profession.
+* Fixed Distiller profession not giving bonuses.
+* Fixed not being able to select Distiller profession.
+* Fixed Distiller profession taking away money.
+
+## 1.4
+* Added Distiller profession.
+* Added Distiller Craft category.
+* Changed hover tooltip to show item name as well as time remaining.
+* Reduced clutter in the winery interior.
+* Fixed small bugs.
+
+## 1.3
+* Added MTN compatibility.
+* Fixed some small bugs.
+* Optimised code.
+
+## 1.2
+* Fixed kegs not getting the 30% bonus while sleeping.
+* Fixed seasonal textures not loading.
+* Added update keys.
+
+## 1.1
+* Added seasonal building textures. Art provided by a person in the credits. :D
+* Fixed an error with moving the Winery building in Robin's Carpenter Shop.
+* Preparing for upcoming Distilled Craft category (beer, mead, IPA, and wines).
+
+## 1.0
+* Initial release.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,6 +7,7 @@
 * Fixed errors due to broken syntax in the i18n files.
 * Fixed errors when a winery is outside the map bounds (e.g. because a custom map was removed).
 * Fixed lag inside the winery for some players.
+* Fixed exit not always putting players in front of the winery.
 
 ## 1.9
 * HOPEFULLY fixed Distiller craft bug.

--- a/SauvignonInStardew/ModEntry.cs
+++ b/SauvignonInStardew/ModEntry.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Harmony;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Netcode;
 using Newtonsoft.Json;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -803,6 +804,7 @@ namespace SauvignonInStardew
                         b.buildingType.Value = "Winery";
                         b.indoors.Value.mapPath.Value = "Maps\\Winery";
                         b.indoors.Value.updateMap();
+                        this.Helper.Reflection.GetField<NetArray<bool, NetBool>>(b.indoors.Value, "waterSpots").GetValue().Clear(); // avoid lag due to the game trying to set a non-existent tile's property in SlimeHutch::UpdateWhenCurrentLocation
                         this.SetArch(b, true);
                     }
                 }

--- a/SauvignonInStardew/ModEntry.cs
+++ b/SauvignonInStardew/ModEntry.cs
@@ -380,7 +380,9 @@ namespace SauvignonInStardew
                     b.indoors.Value.mapPath.Value = "Maps\\Winery";
                     b.indoors.Value.updateMap();
                     b.updateInteriorWarps();
-                    this.Helper.Reflection.GetField<NetArray<bool, NetBool>>(b.indoors.Value, "waterSpots").GetValue().Clear(); // avoid lag due to the game trying to set a non-existent tile's property in SlimeHutch::UpdateWhenCurrentLocation
+                    this.Helper.Reflection
+                        .GetField<NetArray<bool, NetBool>>(b.indoors.Value, "waterSpots", required: false)
+                        ?.GetValue().Clear(); // avoid lag due to the game trying to set a non-existent tile's property in SlimeHutch::UpdateWhenCurrentLocation
                     this.SetArch(b, true);
                 }
             }

--- a/SauvignonInStardew/ModEntry.cs
+++ b/SauvignonInStardew/ModEntry.cs
@@ -456,15 +456,15 @@ namespace SauvignonInStardew
 
 
 
-            /*
-             * RESTORE WINERY DATA AFTER MENU EXITS
-             * 
-             * ADD WINERY TO CARPENTER MENU
-             * 
-             * CHANGE FARMING LEVEL UP 10 MENU TO DISTILLER MENU
-             * 
-             * SAVE BED TIME FOR KEG BONUS OVERNIGHT
-             */
+        /*
+         * RESTORE WINERY DATA AFTER MENU EXITS
+         * 
+         * ADD WINERY TO CARPENTER MENU
+         * 
+         * CHANGE FARMING LEVEL UP 10 MENU TO DISTILLER MENU
+         * 
+         * SAVE BED TIME FOR KEG BONUS OVERNIGHT
+         */
         /// <summary>Raised after a game menu is opened, closed, or replaced.</summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event arguments.</param>
@@ -613,7 +613,7 @@ namespace SauvignonInStardew
             var tilesheet = farm.map.TileSheets.FirstOrDefault(sheet => sheet.ImageSource != null && (sheet.ImageSource.Contains("outdoor") || sheet.ImageSource.Contains("Outdoor")));
 
             // validate
-            if ((building.tileX.Value + maxOffset.X) >= layer.LayerHeight || (building.tileY.Value + maxOffset.Y) >= layer.LayerHeight)
+            if ((building.tileX.Value + maxOffset.X) >= layer.LayerWidth || (building.tileY.Value + maxOffset.Y) >= layer.LayerHeight)
             {
                 this.Monitor.Log($"Didn't apply map changes for winery at ({building.tileX.Value}, {building.tileY.Value}) because it's outside the map bounds.", LogLevel.Warn);
                 return;

--- a/SauvignonInStardew/ModEntry.cs
+++ b/SauvignonInStardew/ModEntry.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,6 +6,7 @@ using System.Reflection;
 using Harmony;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Newtonsoft.Json;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -741,9 +742,11 @@ namespace SauvignonInStardew
             }
 
             // from legacy JSON file
-            // Note: don't change to `this.Helper.Data.ReadJsonFile`, which doesn't allow absolute paths.
             {
-                var data = this.Helper.ReadJsonFile<List<KeyValuePair<int, int>>>($"{Constants.CurrentSavePath}/Winery_Coords.json");
+                FileInfo legacyFile = new FileInfo(Path.Combine($"{Constants.CurrentSavePath}", "Winery_Coords.json"));
+                var data = legacyFile.Exists
+                    ? JsonConvert.DeserializeObject<List<KeyValuePair<int, int>>>(File.ReadAllText(legacyFile.FullName))
+                    : null;
                 if (data != null)
                 {
                     return new SaveData

--- a/SauvignonInStardew/SauvignonInStardew.csproj
+++ b/SauvignonInStardew/SauvignonInStardew.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0-beta-20180819" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/SauvignonInStardew/SauvignonInStardew.csproj
+++ b/SauvignonInStardew/SauvignonInStardew.csproj
@@ -30,6 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/SauvignonInStardew/manifest.json
+++ b/SauvignonInStardew/manifest.json
@@ -1,10 +1,10 @@
 {
   "Name": "Sauvignon in Stardew",
   "Author": "Jesse",
-  "Version": "2.0",
-  "Description": "Adds a new building to the Carpenter Menu. Adds an optional Distiller Profession.",
+  "Version": "2.0.0",
+  "Description": "Adds a new building to the Carpenter Menu, and an optional Distiller profession.",
   "UniqueID": "Jesse.SauvignonInStardew",
   "EntryDll": "SauvignoninStardew.dll",
-  "MinimumApiVersion": "2.8-beta",
-  "UpdateKeys": ["Nexus:2597"]
+  "MinimumApiVersion": "2.9.3",
+  "UpdateKeys": [ "Nexus:2597" ]
 }

--- a/SauvignonInStardew/manifest.json
+++ b/SauvignonInStardew/manifest.json
@@ -4,7 +4,7 @@
   "Version": "2.0.0",
   "Description": "Adds a new building to the Carpenter Menu, and an optional Distiller profession.",
   "UniqueID": "Jesse.SauvignonInStardew",
-  "EntryDll": "SauvignoninStardew.dll",
+  "EntryDll": "SauvignonInStardew.dll",
   "MinimumApiVersion": "2.9.3",
   "UpdateKeys": [ "Nexus:2597" ]
 }

--- a/StardewMods.sln
+++ b/StardewMods.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2035
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28407.52
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SauvignonInStardew", "SauvignonInStardew\SauvignonInStardew.csproj", "{9462B13A-0E4A-422D-8194-D8ECB8A27232}"
 EndProject
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "root", "root", "{8CD749FC-D
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		README.md = README.md
+		RELEASE-NOTES.md = RELEASE-NOTES.md
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
This pull request...

* Updates the code for SMAPI 3.0 (still compatible with current versions of SMAPI).
* Expands `README.md`, and adds `RELEASE-NOTES.md` based on Nexus releases and GitHub pull requests.
* Fixes an incorrect 'outside the map bounds' error in some cases.
* Fixes lag for some players due to the `SlimeHutch` lag trying to handle non-existent water source tiles.
* Fixes the exit warp not putting players in front of the winery.
* Fixes a dll-not-found error on Linux/Mac.

Let me know if you want me to change anything! 

I kept your 2.0 work in the branch, but if these changes look fine can you deploy [SauvignonInStardew 1.9.1.zip](https://github.com/JDvickery/Sauvignon-in-Stardew/files/2775147/SauvignonInStardew.1.9.1.zip) to the [Nexus mod page](https://www.nexusmods.com/stardewvalley/mods/2597)?